### PR TITLE
fixed issue with uninitialized struct field that caused tests to fail

### DIFF
--- a/bchain/coins/viacoin/viacoin_test.go
+++ b/bchain/coins/viacoin/viacoin_test.go
@@ -93,6 +93,7 @@ func init() {
 		Blocktime: 1530319242,
 		Txid:      "d0284c75a389a07cc256e0bb913110d8d8059efd04daa8147ecf2fa0b3bdf6ff",
 		LockTime:  5159274,
+		Version:   2,
 		Vin: []bchain.Vin{
 			{
 				ScriptSig: bchain.ScriptSig{


### PR DESCRIPTION
the packedTx test case had a version field non initialized therefore it was always equal to 0 since Golang initalizes types to 0 . This field (version) needed to be initialized to 2 .